### PR TITLE
CI Jobs: remove old macos image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -257,9 +257,6 @@ stages:
           mac_11:
             os_image: 'macos-11'
             agent_pool: 'Azure Pipelines'
-          mac_10_15:
-            os_image: 'macos-10.15'
-            agent_pool: 'Azure Pipelines'
       
           windows_2022:
             os_image: 'windows-2022'


### PR DESCRIPTION
macos 10.15 will no longer be supported.